### PR TITLE
Fix for Beacon on unnetworked devices

### DIFF
--- a/midas/utilities.py
+++ b/midas/utilities.py
@@ -65,8 +65,8 @@ class Beacon(object):
 
     def broadcast(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        #s.bind(('', 0))
-        #s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        s.bind(('', 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 
         target ='<broadcast>'
         while self.is_running:

--- a/midas/utilities.py
+++ b/midas/utilities.py
@@ -73,9 +73,8 @@ class Beacon(object):
             try:
                 s.sendto(self.data, (target, self.port_broadcast))
             except OSError:
-                print('Switching to localhost')
+                print('Broadcast error in beacon. Switching to localhost.')
                 target = 'localhost'
-                #print('Broadcast error in beacon.')
             time.sleep(self.interval)
     # -------------------------------------------------------------------------
 

--- a/midas/utilities.py
+++ b/midas/utilities.py
@@ -65,14 +65,17 @@ class Beacon(object):
 
     def broadcast(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.bind(('', 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        #s.bind(('', 0))
+        #s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 
+        target ='<broadcast>'
         while self.is_running:
             try:
-                s.sendto(self.data, ('<broadcast>', self.port_broadcast))
+                s.sendto(self.data, (target, self.port_broadcast))
             except OSError:
-                print('Broadcast error in beacon.')
+                print('Switching to localhost')
+                target = 'localhost'
+                #print('Broadcast error in beacon.')
             time.sleep(self.interval)
     # -------------------------------------------------------------------------
 


### PR DESCRIPTION
The current implementation of Beacon relies on a UDP broadcast for service discovery. The broadcast fails, if the only available network interface is the loopback, which doesn't support broadcasting. In this branch the behaviour is changed so that, if an error occurs, the "broadcast" packets are sent to localhost instead.

Note for future: IPv6 does not support broadcast packets at all. Thus, the more involved correct solution will be to implement the beacon using multicast packets.