### PR TITLE
Streamdrop

### DIFF
--- a/midas/node.py
+++ b/midas/node.py
@@ -187,7 +187,7 @@ class BaseNode(object):
 
             if self.channel_descriptions is None:
                 self.channel_descriptions = [''] * self.n_channels
-            self.last_sample_received = time.time()
+            self.last_sample_received = mp.Value('f', time.time())
 
         else:
             self.lsl_stream_name = ['']
@@ -654,7 +654,7 @@ class BaseNode(object):
                                                        request['channels'],
                                                        time_window)
                     if self.primary_node:
-                        last_sample = time.time() - self.last_sample_received
+                        last_sample = time.time() - self.last_sample_received.value
                         request['last_sample_received'] = last_sample
 
                 else:
@@ -707,7 +707,7 @@ class BaseNode(object):
                     time_window = None
 
                 if self.primary_node:
-                    last_sample = time.time() - self.last_sample_received
+                    last_sample = time.time() - self.last_sample_received.value
                     request['last_sample_received'] = last_sample
 
                 data, times = self.unpack_snapshot(snapshot, channels,

--- a/midas/node.py
+++ b/midas/node.py
@@ -324,7 +324,7 @@ class BaseNode(object):
         self.last_time.value = 0  # init the last_time value
         while self.run_state.value:
             x, t = inlet.pull_sample()
-            self.last_sample_received = time.time()
+            self.last_sample_received.value = time.time()
 
             self.lock_primary.acquire()  # LOCK-ON
 

--- a/midas/node.py
+++ b/midas/node.py
@@ -187,7 +187,7 @@ class BaseNode(object):
 
             if self.channel_descriptions is None:
                 self.channel_descriptions = [''] * self.n_channels
-            self.last_sample_received = mp.Value('f', time.time())
+            self.last_sample_received = mp.Value('d', time.time())
 
         else:
             self.lsl_stream_name = ['']


### PR DESCRIPTION
Metric and data request from primary nodes now return a value that indicates the time elapsed since the last sample was received from the input stream. This feature can be used to detect problems with the LSL stream.